### PR TITLE
Include Enum in NinjaJsonEncoder

### DIFF
--- a/ninja/responses.py
+++ b/ninja/responses.py
@@ -1,5 +1,6 @@
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any, FrozenSet
+from enum import Enum
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import JsonResponse
@@ -21,6 +22,8 @@ class NinjaJSONEncoder(DjangoJSONEncoder):
         if isinstance(o, BaseModel):
             return o.model_dump()
         if isinstance(o, (IPv4Address, IPv6Address)):
+            return str(o)
+        if isinstance(o, Enun):
             return str(o)
         return super().default(o)
 


### PR DESCRIPTION
This would allow proper usage of enums in path parameters
Currently if you want to have an enum in the path, you would do this.
```
enum_value: SomeEnumClass = Path(...),
```
Which works fine until the request path includes an enum value that does not exist.
ie.
```
class SomeEnumClass(enum.Enum):
    first: "first"
    second: "second"

requests.get("some_path/third/other")
```

This would return a 500 instead of an expected 422 due to crashing in the JSONEncoder.
Returning and error
```
TypeError: Object of type SomeEnumClass is not JSON serializable"
```